### PR TITLE
Pass client vs. url/token into build report fn

### DIFF
--- a/lib/StaticNarrative/exporter/app_processor.py
+++ b/lib/StaticNarrative/exporter/app_processor.py
@@ -1,5 +1,6 @@
 from installed_clients.WorkspaceClient import Workspace
 from installed_clients.NarrativeMethodStoreClient import NarrativeMethodStore
+from installed_clients.WorkspaceClient import Workspace
 from .processor_util import build_report_view_data
 import re
 import math
@@ -39,10 +40,11 @@ class AppProcessor:
         elif "job_output" in job_state:  # EE2
             exec_result = job_state["job_output"].get("result")
 
+        ws_client = Workspace(self.ws_url, token=self.token)
         kb_info["output"] = {
             "widget": exec_state.get("outputWidgetInfo", {}),
             "result": exec_result,
-            "report": build_report_view_data(self.host, self.ws_url, self.token, exec_result)
+            "report": build_report_view_data(self.host, ws_client, exec_result)
         }
         kb_info["job"] = {
             "state": "This app is new, and hasn't been started."

--- a/lib/StaticNarrative/exporter/processor_util.py
+++ b/lib/StaticNarrative/exporter/processor_util.py
@@ -18,7 +18,7 @@ def _load_icon_data():
         ICON_DATA = json.load(icon_file)
 
 
-def build_report_view_data(host: str, ws_url: str, token: str, result: list) -> dict:
+def build_report_view_data(host: str, ws_client: Workspace, result: list) -> dict:
     """
     Returns a structure like this:
     {
@@ -67,8 +67,7 @@ def build_report_view_data(host: str, ws_url: str, token: str, result: list) -> 
             not result[0].get('report_ref')):
         return {}
     report_ref = result[0]['report_ref']
-    ws = Workspace(url=ws_url, token=token)
-    report = ws.get_objects2({'objects': [{'ref': report_ref}]})['data'][0]['data']
+    report = ws_client.get_objects2({'objects': [{'ref': report_ref}]})['data'][0]['data']
     """{'direct_html': None,
      'direct_html_link_index': None,
      'file_links': [],
@@ -84,7 +83,7 @@ def build_report_view_data(host: str, ws_url: str, token: str, result: list) -> 
         report_objs_created = report['objects_created']
         # make list to look up obj types with get_object_info3
         info_lookup = [{"ref": o["ref"]} for o in report_objs_created]
-        infos = ws.get_object_info3({'objects': info_lookup})['infos']
+        infos = ws_client.get_object_info3({'objects': info_lookup})['infos']
         for idx, info in enumerate(infos):
             created_objs.append({
                 'upa': report_objs_created[idx]['ref'],


### PR DESCRIPTION
Allows client to be mocked so build_report_view_data can be unit tested