### PR TITLE
UIP-29 update GA tag

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # StaticNarrative release notes
 =========================================
 
+0.0.15
+------
+* UIP-29 Update the Google analytics tracking tag
+
 0.0.14
 ------
 * Fixed a bug that caused a None comparison error when processing a specific configuration of a

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,11 +8,11 @@ service-language:
     python
 
 module-version:
-    0.0.14
+    0.0.15
 
 service-config:
     dynamic-service: true
 
 owners:
-    [wjriehl]
+    [wjriehl, ialarmedalien]
 

--- a/lib/StaticNarrative/exporter/static/templates/narrative.tpl
+++ b/lib/StaticNarrative/exporter/static/templates/narrative.tpl
@@ -7,12 +7,12 @@
 <html>
 <head>
 {%- block html_head -%}
-<script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-137652528-1"></script>
+<script async="" src="https://www.googletagmanager.com/gtag/js?id=G-KXZCE6YQFZ"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'UA-137652528-1');
+  gtag('config', 'G-KXZCE6YQFZ');
   gtag('config', 'AW-753507180'); //tracking for Google Ads
 </script><!-- End of Global Site Tag (gtag.js) - Google Analytics -->
 <meta charset="utf-8" />


### PR DESCRIPTION
Updates the Google Analytics tag to the new GA4 one.

Looking at it, this really isn't ideal to just have it squashed into the template. Ideally it should get looked up from some parent source like kbase-ui or narrative. But as other bits of machinery are in flux, and this isn't the highest priority, this will work for now.