### PR TITLE
SN 1.5: adding the DataCite view tracker

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # StaticNarrative release notes
 =========================================
 
+0.0.15
+------
+* Added DataCite view tracker to static narrative template.
+
 0.0.14
 ------
 * Fixed a bug that caused a None comparison error when processing a specific configuration of a

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,11 +8,10 @@ service-language:
     python
 
 module-version:
-    0.0.14
+    0.0.15
 
 service-config:
     dynamic-service: true
 
 owners:
     [wjriehl]
-

--- a/lib/StaticNarrative/exporter/static/templates/narrative.tpl
+++ b/lib/StaticNarrative/exporter/static/templates/narrative.tpl
@@ -1,7 +1,5 @@
 {%- extends 'narrative_basic.tpl' -%}
 {% from 'mathjax.tpl' import mathjax %}
-
-
 {%- block header -%}
 <!DOCTYPE html>
 <html>
@@ -15,6 +13,11 @@
   gtag('config', 'UA-137652528-1');
   gtag('config', 'AW-753507180'); //tracking for Google Ads
 </script><!-- End of Global Site Tag (gtag.js) - Google Analytics -->
+<!-- DataCite view tracker code -->
+<script defer
+        data-repoid="da-wsbych"
+        data-metric="view"
+        src="https://cdn.jsdelivr.net/npm/@datacite/datacite-tracker"></script>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="keywords" content="{{ resources.kbase.meta_keywords }}" />


### PR DESCRIPTION
Adding the DataCite view tracker to the header of static narrative pages.

See https://support.datacite.org/docs/datacite-usage-tracker for more on the view tracker.