### PR TITLE
SN 1.5: Move over NarrativeService modules

### DIFF
--- a/lib/StaticNarrative/exporter/dynamic_service_client.py
+++ b/lib/StaticNarrative/exporter/dynamic_service_client.py
@@ -1,0 +1,74 @@
+"""Client for dealing with KBase dynamic services."""
+
+import time
+
+from installed_clients.baseclient import BaseClient, ServerError
+
+
+class DynamicServiceClient:
+    def __init__(
+        self: "DynamicServiceClient",
+        sw_url: str,
+        service_ver: str,
+        module_name: str,
+        token: str,
+        url_cache_time: int = 300,
+    ) -> None:
+        """Initialise a dynamic service client.
+
+        :param self: this class
+        :type self: DynamicServiceClient
+        :param sw_url: service worker URL
+        :type sw_url: str
+        :param service_ver: service version
+        :type service_ver: str
+        :param module_name: module to be accessed
+        :type module_name: str
+        :param token: KBase auth
+        :type token: str
+        :param url_cache_time: time in seconds to cache the URL for, defaults to 300
+        :type url_cache_time: int, optional
+        """
+        self.sw_url = sw_url
+        self.service_ver = service_ver
+        self.module_name = module_name
+        self.url_cache_time = url_cache_time
+        self.cached_url = None
+        self.last_refresh_time = None
+        self.token = token
+
+    def call_method(
+        self: "DynamicServiceClient", method: str, params_array: list
+    ) -> list:
+        """
+        Calls the given method. Uses the BaseClient and cached service URL.
+        """
+        was_url_refreshed = False
+        if not self.cached_url or (
+            time.time() - self.last_refresh_time > self.url_cache_time
+        ):
+            self._lookup_url()
+            was_url_refreshed = True
+        try:
+            return self._call(method, params_array, self.token)
+        except ServerError:
+            # Happens if a URL expired for real, even though it's still cached.
+            if was_url_refreshed:
+                raise  # Forwarding error with no changes
+            self._lookup_url()
+            method_call_return = self._call(method, params_array, self.token)
+            return method_call_return
+
+    def _lookup_url(self: "DynamicServiceClient") -> None:
+        bc = BaseClient(url=self.sw_url, lookup_url=False)
+        self.cached_url = bc.call_method(
+            "ServiceWizard.get_service_status",
+            [{"module_name": self.module_name, "version": self.service_ver}],
+        )["url"]
+        self.last_refresh_time = time.time()
+
+    def _call(
+        self: "DynamicServiceClient", method: str, params_array: list, token: str
+    ) -> list:
+        bc = BaseClient(url=self.cached_url, token=token, lookup_url=False)
+        return bc.call_method(self.module_name + "." + method, params_array)

--- a/lib/StaticNarrative/exporter/exporter.py
+++ b/lib/StaticNarrative/exporter/exporter.py
@@ -64,7 +64,11 @@ class NarrativeExporter:
 
         # 3. Export the Narrative workspace data to a sidecar JSON file.
         exported_data = export_narrative_data(
-            narrative_ref.wsid, output_dir, self.exporter_cfg["srv-wiz-url"], self.token
+            self.ws_client,
+            narrative_ref.wsid,
+            output_dir,
+            self.exporter_cfg["srv-wiz-url"],
+            self.token,
         )
 
         # 4. Export the Narrative to an HTML file

--- a/lib/StaticNarrative/exporter/objectswithsets.py
+++ b/lib/StaticNarrative/exporter/objectswithsets.py
@@ -1,0 +1,134 @@
+import json
+import os
+from typing import Any
+
+from installed_clients.WorkspaceClient import Workspace
+
+from StaticNarrative.exporter.dynamic_service_client import DynamicServiceClient
+from StaticNarrative.exporter.workspace_list_objects_iterator import (
+    WorkspaceListObjectsIterator,
+)
+
+
+class ObjectsWithSets:
+    def __init__(
+        self: "ObjectsWithSets",
+        set_api_client: DynamicServiceClient,
+        workspace_client: Workspace,
+    ) -> None:
+        self.set_api_client = set_api_client
+        self.ws_client = workspace_client
+
+    def list_objects_with_sets(
+        self: "ObjectsWithSets",
+        ws_id: int | None = None,
+        types: list[str] | None = None,
+        include_metadata: int = 0,
+        outdir: str = "",
+        **kwargs,
+    ) -> dict[str, Any]:
+        if not ws_id:
+            raise ValueError("ws_id is required")
+        return self._list_objects_with_sets([ws_id], types, include_metadata, outdir)
+
+    def _check_info_type(
+        self: "ObjectsWithSets", info: list[str | Any], type_map: dict[str | Any]
+    ) -> bool:
+        if type_map is None:
+            return True
+        obj_type = info[2].split("-")[0]
+        return type_map.get(obj_type, False)
+
+    def _list_objects_with_sets(
+        self: "ObjectsWithSets",
+        workspaces: list[int | str],
+        types: list[str],
+        include_metadata: int,
+        outdir: str,
+    ) -> list[dict[str, Any]]:
+        """
+
+        :param self: _description_
+        :type self: ObjectsWithSets
+        :param workspaces: _description_
+        :type workspaces: list[int  |  str]
+        :param types: _description_
+        :type types: list[str]
+        :param include_metadata: _description_
+        :type include_metadata: int
+        :param outdir: _description_
+        :type outdir: str
+        :return: _description_
+        :rtype: dict[str, Any]
+        """
+        type_map = None
+        if types is not None:
+            type_map = {key: True for key in types}
+
+        processed_refs = {}
+        data = []
+        set_ret = self.set_api_client.call_method(
+            "list_sets",
+            [
+                {
+                    "workspaces": workspaces,
+                    "include_set_item_info": 1,
+                    "include_metadata": include_metadata,
+                    # TODO: implement infostruct returns!
+                    # "infostruct": 1,
+                }
+            ],
+        )
+
+        # report_path = os.path.join(outdir, "list_sets.json")
+        # with open(report_path, "w") as fout:
+        #     json.dump(set_ret, fout, indent=2, sort_keys=True)
+
+        # return unless there are some sets in the workspace
+        if not set_ret or "sets" not in set_ret:
+            return data
+
+        sets = set_ret["sets"]
+        for set_info in sets:
+            # Process
+            target_set_items = [set_item["info"] for set_item in set_info["items"]]
+            if self._check_info_type(set_info["info"], type_map):
+                data_item = {
+                    "object_info": set_info["info"],
+                    "set_items": {"set_items_info": target_set_items},
+                }
+                data.append(data_item)
+                processed_refs[set_info["ref"]] = data_item
+
+        ws_info_list = []
+        if len(workspaces) == 1:
+            ws = workspaces[0]
+            ws_id = None
+            ws_name = None
+            if str(ws).isdigit():
+                ws_id = int(ws)
+            else:
+                ws_name = str(ws)
+            ws_info_list.append(
+                self.ws_client.get_workspace_info({"id": ws_id, "workspace": ws_name})
+            )
+        else:
+            ws_map = {key: True for key in workspaces}
+            ws_info_list = [
+                ws_info
+                for ws_info in self.ws_client.list_workspace_info({"perm": "r"})
+                if ws_info[1] in ws_map or str(ws_info[0]) in ws_map
+            ]
+
+        for info in WorkspaceListObjectsIterator(
+            self.ws_client,
+            ws_info_list=ws_info_list,
+            list_objects_params={"includeMetadata": include_metadata},
+        ):
+            item_ref = f"{info[6]}/{info[0]}/{info[4]}"
+            if item_ref not in processed_refs and self._check_info_type(info, type_map):
+                data_item = {"object_info": info}
+                data.append(data_item)
+                processed_refs[item_ref] = data_item
+
+        return data

--- a/lib/StaticNarrative/exporter/workspace_list_objects_iterator.py
+++ b/lib/StaticNarrative/exporter/workspace_list_objects_iterator.py
@@ -1,0 +1,99 @@
+"""Class for fetching objects from the workspace."""
+from collections import deque
+
+from installed_clients.WorkspaceClient import Workspace
+
+
+class WorkspaceListObjectsIterator:
+    # ws_info - optional workspace info tuple (if is not defined then either ws_id
+    #    or ws_name should be provided),
+    # ws_id/ws_name - optional workspace identification (if neither is defined
+    #    then ws_info should be provided),
+    # list_objects_params - optional structure with such Woskspace.ListObjectsParams
+    #    as 'type' or 'before', 'after', 'showHidden', 'includeMetadata' and so on,
+    #    wherein there is no need to set 'ids' or 'workspaces' or 'min/maxObjectID'.
+    def __init__(
+        self: "WorkspaceListObjectsIterator",
+        ws_client: Workspace,
+        ws_info_list=None,
+        ws_id=None,
+        ws_name=None,
+        list_objects_params=None,
+        part_size=10000,
+        global_limit=100000,
+    ) -> None:
+        if not list_objects_params:
+            list_objects_params = {}
+        self.ws_client = ws_client
+        if ws_info_list is None:
+            if ws_id is None and ws_name is None:
+                raise ValueError(
+                    "In case ws_info_list is not set either ws_id or ws_name should be set"
+                )
+            ws_info_list = [
+                self.ws_client.get_workspace_info({"id": ws_id, "workspace": ws_name})
+            ]
+        # Let's split workspaces into blocks
+        blocks = []  # Each block is array of ws_info
+        sorted_ws_info_deque = deque(sorted(ws_info_list, key=lambda x: x[4]))
+        while sorted_ws_info_deque:
+            block_size = 0
+            block = []
+            while sorted_ws_info_deque:
+                item = sorted_ws_info_deque.popleft()
+                if len(block) == 0 or block_size + item[4] <= part_size:
+                    block.append(item)
+                    block_size += item[4]
+                else:
+                    sorted_ws_info_deque.appendleft(item)
+                    break
+            blocks.append(block)
+        self.block_iter = blocks.__iter__()
+        self.list_objects_params = list_objects_params
+        self.min_obj_id = -1
+        self.max_obj_count = -1
+        self.part_size = part_size
+        self.global_limit = global_limit
+        self.total_counter = 0
+        self.part_iter = self._load_next_part()
+
+    # iterator implementation
+    def __iter__(
+        self: "WorkspaceListObjectsIterator",
+    ) -> "WorkspaceListObjectsIterator":
+        return self
+
+    def __next__(
+        self: "WorkspaceListObjectsIterator",
+    ):
+        while self.part_iter is not None:
+            try:
+                self.total_counter += 1
+                if (
+                    self.global_limit is not None
+                    and self.total_counter > self.global_limit
+                ):
+                    raise StopIteration
+                return next(self.part_iter)
+            except StopIteration:
+                self.part_iter = self._load_next_part()
+        raise StopIteration
+
+    def _load_next_part(
+        self: "WorkspaceListObjectsIterator",
+    ) -> "WorkspaceListObjectsIterator":
+        if self.min_obj_id < 0 or self.min_obj_id > self.max_obj_count:
+            try:
+                block = next(self.block_iter)
+                self.list_objects_params["ids"] = [ws_info[0] for ws_info in block]
+            except StopIteration:
+                return None
+            last_ws_info = block[len(block) - 1]
+            self.min_obj_id = 1
+            self.max_obj_count = last_ws_info[4]
+        max_obj_id = self.min_obj_id + self.part_size - 1
+        self.list_objects_params["minObjectID"] = self.min_obj_id
+        self.list_objects_params["maxObjectID"] = max_obj_id
+        self.min_obj_id += self.part_size  # For next load cycle
+        ret = self.ws_client.list_objects(self.list_objects_params)
+        return ret.__iter__()

--- a/test/exporter_test.py
+++ b/test/exporter_test.py
@@ -52,10 +52,9 @@ class ExporterTest(unittest.TestCase):
             user_map=user_map,
             ws_obj_info_file="data/43666/objects-43666.json",
         )
+
         exporter = NarrativeExporter(self.cfg, self.user_id, self.token)
         static_path = exporter.export_narrative(
             NarrativeRef({"wsid": ws_id, "objid": 1, "ver": 21}), self.cfg["scratch"]
         )
-        self.assertEqual(
-            static_path, os.path.join(self.cfg["scratch"], "narrative.html")
-        )
+        assert static_path == os.path.join(self.cfg["scratch"], "narrative.html")

--- a/test/mocks.py
+++ b/test/mocks.py
@@ -89,7 +89,7 @@ def _mock_adapter(
                 result = [
                     {"url": "https://something.kbase.us/service/narrative_service_url"}
                 ]
-            elif method == "NarrativeService.list_objects_with_sets":
+            elif "list_objects_with_sets" in method:
                 if ws_obj_info_file is not None:
                     result = [_get_object_from_file(ws_obj_info_file)]
                 else:


### PR DESCRIPTION
# Description of PR purpose/changes

Basic C&P of the Narrative Service method used by the StaticNarrative into the SN repo.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code
- [x] If appropriate, I have recompiled the app and added the updated `StaticNarrativeImpl.py`, `StaticNarrativeServer.py`, and `compile_report.json` to this PR.

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
