### PR TITLE
Dependabot targets the develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+target-branch: develop
 updates:
 - package-ecosystem: docker
   directory: "/"


### PR DESCRIPTION
# Description of PR purpose/changes

Have dependabot check against the `develop` branch, instead of `main`.